### PR TITLE
fix(useDayjs hook)

### DIFF
--- a/src/runtime/composables/dayjs.ts
+++ b/src/runtime/composables/dayjs.ts
@@ -1,7 +1,7 @@
 import { useNuxtApp } from '#app'
-import dayjs, { Dayjs } from 'dayjs'
+import { Dayjs } from 'dayjs'
 
-export const useDayjs = (date?: dayjs.ConfigType): Dayjs => {
+export const useDayjs = (): Dayjs => {
   const { $dayjs } = useNuxtApp()
-  return $dayjs(date)
+  return $dayjs
 }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -3,20 +3,19 @@ import { defineNuxtPlugin } from '#app'
 
 declare module '#app' {
   interface NuxtApp {
-    $dayjs(date?: dayjs.ConfigType): dayjs.Dayjs
+    $dayjs: dayjs.Dayjs
   }
 }
 
 declare module 'vue' {
   interface ComponentCustomProperties {
-    $dayjs(date?: dayjs.ConfigType): dayjs.Dayjs
+    $dayjs: dayjs.Dayjs
   }
 }
 
 declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
-    $dayjs(date?: dayjs.ConfigType): dayjs.Dayjs
-
+    $dayjs: dayjs.Dayjs
   }
 }
 


### PR DESCRIPTION
This fixes `dayjs is not a function` error when trying to use it according to documentation.