### PR TITLE
Add 'updateLocale' plugin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export default defineNuxtConfig({
   modules: ['dayjs-nuxt'],
   dayjs: {
     locales: ['en', 'fr'],
-    plugins: ['relativeTime', 'utc', 'timezone'],
+    plugins: ['relativeTime', 'utc', 'timezone', 'updateLocale'],
     defaultLocale: 'en',
     defaultTimezone: 'America/New_York',
   }
@@ -102,7 +102,7 @@ export default defineNuxtConfig({
   modules: ['dayjs-nuxt'],
   dayjs: {
     locales: ['en', 'fr'],
-    plugins: ['relativeTime'],
+    plugins: ['relativeTime', 'updateLocale'],
     defaultLocale: ['en', {
       relativeTime: {
         future: "in %s",


### PR DESCRIPTION
When using locales without the updateLocale plugin, nuxt throws a 500 error. 
This PR simply adds the plugin to the documentation in case someone else runs into the same problem when copying and pasting the configuration.