### PR TITLE
Update dayjs.ts

### DIFF
--- a/src/runtime/composables/dayjs.ts
+++ b/src/runtime/composables/dayjs.ts
@@ -1,7 +1,7 @@
 import { useNuxtApp } from '#app'
-import dayjs, { Dayjs } from 'dayjs'
+import dayjs from 'dayjs'
 
-export const useDayjs = (date?: dayjs.ConfigType): Dayjs => {
+export const useDayjs = (date?: dayjs.ConfigType): typeof dayjs => {
   const { $dayjs } = useNuxtApp()
   return $dayjs(date)
 }


### PR DESCRIPTION
When we're using dayjs module in composable logic declared types don't show. This fix has to fix the issue.

![image](https://github.com/fumeapp/dayjs/assets/20489824/c3b518ed-8f3a-4f28-914f-561134a3b46b)
