### PR TITLE
[FEAT]: `dayjs()` as composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,18 @@ You can use the provided `$dayjs` to access Day.js in template.
 
 ## Composables
 
-You can use the useDayjs composable to access Day.js anywhere.
+You can use the `useDayjs()` and `dayjs()` composables to access Day.js anywhere.
 
-```js
+```vue
 <script setup>
-  import { useDayjs } from '#dayjs' // not need if you are using auto import
-  const dayjs = useDayjs()
-  dayjs.locale('fr')
-  dayjs.extend(...)
+  import { useDayjs, dayjs } from '#dayjs' // not need if you are using auto import
+
+  // access for dayjs globals
+  useDayjs().locale('fr')
+  useDayjs().extend(...)
+
+  // access for dayjs instance
+  console.log(dayjs().format('YYYY-MM-DD HH:mm:ss'))
 </script>
 ```
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
-import { useDayjs } from '#dayjs'
+import { dayjs, useDayjs } from '#dayjs'
 
-const dayjs = useDayjs()
 const card = false
 const icon = false
 
 // access for dayjs instance
-console.log(dayjs(new Date()).format('YYYY-MM-DD HH:mm:ss'))
+console.log(dayjs().format('YYYY-MM-DD HH:mm:ss'))
+
+// access for dayjs globals
+console.log(useDayjs().isDayjs(new Date()))
 </script>
 
 <template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -114,6 +114,12 @@ export default defineNuxtModule<ModuleOptions>({
       from: nuxt.options.alias['#dayjs'],
     })
 
+    addImports({
+      name: 'dayjs',
+      as: 'dayjs',
+      from: nuxt.options.alias['#dayjs'],
+    })
+
     addTemplate({
       filename: 'dayjs.imports.mjs',
       getContents: () => generateImports(options),

--- a/src/runtime/composables/dayjs.d.ts
+++ b/src/runtime/composables/dayjs.d.ts
@@ -1,3 +1,4 @@
-import type dayjs from '#build/dayjs.imports.mjs'
+import type dayjsImport from '#build/dayjs.imports.mjs';
 
-export declare function useDayjs(): typeof dayjs
+export declare function dayjs(): typeof dayjsImport.Dayjs
+export declare function useDayjs(): typeof dayjsImport

--- a/src/runtime/composables/dayjs.ts
+++ b/src/runtime/composables/dayjs.ts
@@ -1,5 +1,9 @@
-import dayjs from '#build/dayjs.imports.mjs'
+import dayjsImport from '#build/dayjs.imports.mjs'
+
+export function dayjs(...args: Parameters<typeof dayjsImport>) {
+  return dayjsImport(...args)
+}
 
 export function useDayjs() {
-  return dayjs
+  return dayjsImport
 }


### PR DESCRIPTION
# Changelog

### 🚀 Enhancements

- Add a composable to be able to access `dayjs()` directly

### 📖 Documentation

- Documentation and playground supplemented and adjusted for the new `dayjs()` composable

---

Closes: #57 