### PR TITLE
Fix: formats type error

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -24,6 +24,10 @@ interface FormatOptions {
   LL: string
   LLL: string
   LLLL: string
+  l?: string
+  ll?: string
+  lll?: string
+  llll?: string
 }
 
 interface DefaultLocaleOptions {


### PR DESCRIPTION
I added the following configuration to `nuxt.config.ts` in my Nuxt project.

```ts
export default defineNuxtConfig({
  ...
  dayjs: {
    locales: ['ja'],
    plugins: ['relativeTime', 'utc', 'timezone', 'localizedFormat'],
    defaultTimezone: 'Asia/Tokyo',
    defaultLocale: [
      'ja',
      {
        formats: {
          LT: 'HH:mm',
          LTS: 'HH:mm:ss',
          L: 'YYYY/MM/DD',
          LL: 'YYYY年M月D日',
          LLL: 'YYYY年M月D日 HH:mm',
          LLLL: 'YYYY年M月D日 dddd HH:mm',
          l: 'YYYY/MM/DD',
          ll: 'YYYY年M月D日',
          lll: 'YYYY年M月D日 HH:mm',
          llll: 'YYYY年M月D日(ddd) HH:mm',
        },
      },
    ],
  },
})
```

The following type error occurs:

```text
Object literal may only specify known properties, but 'l' does not exist in type 'FormatOptions'. Did you mean to write 'L'? [2561]
```

I have added an option for the types of settings that can be specified.

<https://day.js.org/docs/en/display/format#list-of-localized-formats>
